### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/providers/hlr-lookups-provider.js
+++ b/lib/providers/hlr-lookups-provider.js
@@ -5,7 +5,7 @@
  */
 
 var HlrClient = require('node-hlr-client');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var _ = require('lodash');
 var loggingFunc = require('../logging/logger-message-formatter').getLoggerMessageFunc('hlr-lookups-provider');
 var getLogger = require('../logging/logger-options-parser').getLoggerFromOptions;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "google-libphonenumber": "^1.0.16",
     "lodash": "^4.6.0",
     "node-hlr-client": "^0.0.13",
-    "node-uuid": "^1.4.7",
-    "smsapicom": "^1.2.0"
+    "smsapicom": "^1.2.0",
+    "uuid": "^3.0.0"
   },
   "engine": "node >= 5.6.0",
   "devDependencies": {

--- a/tests/integration/helpers/hlr-lookup.spec.js
+++ b/tests/integration/helpers/hlr-lookup.spec.js
@@ -1,5 +1,5 @@
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var server;
 var PORT = 3000;
 var SERVER_BASE_URL = 'http://localhost:' + PORT;

--- a/tests/mocks/mock-hlr-lookups-client.js
+++ b/tests/mocks/mock-hlr-lookups-client.js
@@ -1,7 +1,7 @@
 var chai = require('chai');
 var _ = require('lodash');
 var url = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var hlrLookupFixtures = require('../fixtures/hlr-lookup-responses.json');
 
 var loggingFunc = require('../../lib/logging/logger-message-formatter').getLoggerMessageFunc('mock-hlr-lookups-client');

--- a/tests/mocks/mock-sms-api-client.js
+++ b/tests/mocks/mock-sms-api-client.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var loggingFunc = require('../../lib/logging/logger-message-formatter').getLoggerMessageFunc('mock-sms-api-client');
 var getLogger = require('../../lib/logging/logger-options-parser').getLoggerFromOptions;
 

--- a/tests/unit/cache/timeout-manager.spec.js
+++ b/tests/unit/cache/timeout-manager.spec.js
@@ -1,6 +1,6 @@
 var chai = require('chai');
 var sinon = require('sinon');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var timeoutManager = require('../../../lib/cache/timeout-manager');
 var keyBuilder = require('../../../lib/cache/key-builder');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.