### PR TITLE
Update dependencies and add a test to verify a brazilian mobile number

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   "dependencies": {
     "cache-manager": "^2.0.1",
     "dotenv": "^2.0.0",
-    "google-libphonenumber": "^1.0.16",
+    "google-libphonenumber": "^3.0.7",
     "lodash": "^4.6.0",
     "node-hlr-client": "^0.0.13",
-    "node-uuid": "^1.4.7",
-    "smsapicom": "^1.2.0"
+    "smsapicom": "^1.2.0",
+    "uuid": "^3.1.0"
   },
   "engine": "node >= 5.6.0",
   "devDependencies": {

--- a/tests/unit/node-phone-utils.spec.js
+++ b/tests/unit/node-phone-utils.spec.js
@@ -158,6 +158,10 @@ describe('Phone Number Utils', function initialTests() {
       expect(phoneUtils.getType(testMobilePhoneNumber.number, testMobilePhoneNumber.regionCode)).to.be.a('number').and.to.eql(phoneUtils.PhoneNumberType.MOBILE);
     });
 
+    it('should get type of valid Brazil mobile phone number to be mobile', function () {
+      expect(phoneUtils.getType('+5541987960672')).to.be.a('number').and.to.eql(phoneUtils.PhoneNumberType.MOBILE);
+    });
+
     it('should get type of valid phone number without region code', function () {
       expect(phoneUtils.getType(testPhoneNumber.number)).to.be.a('number');
     });


### PR DESCRIPTION
Currently the old version og googlelibhonenumber returns unknown for a mobile type for a
Brazilian phone number and updating it will fix the problem.